### PR TITLE
fix: robots.txt에 명시된 sitemap 주소 수정

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -79,7 +79,7 @@ const config: GatsbyConfig = {
       resolve: `gatsby-plugin-robots-txt`,
       options: {
         host: 'https://victor-log.vercel.app',
-        sitemap: 'https://victor-log.vercel.app/sitemap.xml',
+        sitemap: 'https://victor-log.vercel.app/sitemap/sitemap-index.xml',
         policy: [{ userAgent: '*', allow: '/' }],
       },
     },


### PR DESCRIPTION
# fix: robots.txt에 명시된 sitemap 주소 수정

## 작업 내용
- robots.txt를 생성할 때 추가되는 sitemap 주소를 올바르게 수정